### PR TITLE
match all domains ending in pi.alert in lighttpd

### DIFF
--- a/install/pialert_front.conf
+++ b/install/pialert_front.conf
@@ -7,6 +7,6 @@
 #  Puche 2021        pi.alert.application@gmail.com        GNU GPLv3
 # ------------------------------------------------------------------------------
 
-$HTTP["host"] == "pi.alert" {
+$HTTP["host"] =~ "pi\.alert" {
   server.document-root = "/var/www/html/pialert/"
 }


### PR DESCRIPTION
causes lighttpd to match any subdomain of pi.alert (e.g. www.pi.alert) to this virtual server

this addresses issue #54