### PR TITLE
Fix query so that "Domotic" and "Other" do not appear twice in the device list

### DIFF
--- a/front/php/server/devices.php
+++ b/front/php/server/devices.php
@@ -333,9 +333,9 @@ function getDeviceTypes() {
           WHERE dev_DeviceType NOT IN ("",
                  "Smartphone", "Tablet",
                  "Laptop", "Mini PC", "PC", "Printer", "Server", "Singleboard Computer (SBC)",
-                 "Game Console", "SmartTV", "TV Decoder", "Virtual Assistance",
+                 "Domotic", "Game Console", "SmartTV", "TV Decoder", "Virtual Assistance",
                  "Clock", "House Appliance", "Phone", "Radio",
-                 "AP", "NAS", "PLC", "Router")
+                 "AP", "NAS", "PLC", "Router", "USB LAN Adapter", "USB WIFI Adapter")
 
           UNION SELECT 1 as dev_Order, "Smartphone"
           UNION SELECT 1 as dev_Order, "Tablet"

--- a/front/php/server/devices.php
+++ b/front/php/server/devices.php
@@ -335,7 +335,7 @@ function getDeviceTypes() {
                  "Laptop", "Mini PC", "PC", "Printer", "Server", "Singleboard Computer (SBC)",
                  "Domotic", "Game Console", "SmartTV", "TV Decoder", "Virtual Assistance",
                  "Clock", "House Appliance", "Phone", "Radio",
-                 "AP", "NAS", "PLC", "Router", "USB LAN Adapter", "USB WIFI Adapter")
+                 "AP", "NAS", "PLC", "Router", "USB LAN Adapter", "USB WIFI Adapter", "Other")
 
           UNION SELECT 1 as dev_Order, "Smartphone"
           UNION SELECT 1 as dev_Order, "Tablet"


### PR DESCRIPTION
When you assign a device the type of "Domotic" or "Other" that type then appears twice in the types list