### PR TITLE
Allow SMTP configuration without TLS and login

### DIFF
--- a/back/pialert.py
+++ b/back/pialert.py
@@ -1413,12 +1413,19 @@ def send_email (pText, pHTML):
     # Send mail
     smtp_connection = smtplib.SMTP (SMTP_SERVER, SMTP_PORT)
     smtp_connection.ehlo()
-    smtp_connection.starttls()
-    smtp_connection.ehlo()
-    smtp_connection.login (SMTP_USER, SMTP_PASS)
+    if not SafeParseGlobalBool("SMTP_SKIP_TLS"):
+        smtp_connection.starttls()
+        smtp_connection.ehlo()
+    if not SafeParseGlobalBool("SMTP_SKIP_LOGIN"):
+        smtp_connection.login (SMTP_USER, SMTP_PASS)
     smtp_connection.sendmail (REPORT_FROM, REPORT_TO, msg.as_string())
     smtp_connection.quit()
 
+#-------------------------------------------------------------------------------
+def SafeParseGlobalBool(boolVariable):
+    if boolVariable in globals():
+        return eval(boolVariable)
+    return False
 
 #===============================================================================
 # DB

--- a/config/pialert.conf
+++ b/config/pialert.conf
@@ -15,6 +15,8 @@ PRINT_LOG         = False
 
 SMTP_SERVER       = 'smtp.gmail.com'
 SMTP_PORT         = 587
+SMTP_SKIP_TLS	  = False
+SMTP_SKIP_LOGIN	  = False
 SMTP_USER         = 'user@gmail.com'
 SMTP_PASS         = 'password'
 


### PR DESCRIPTION
Add configuration options for skipping TLS and authentication against the SMTP server.

The supplied configuration defaults to the original behaviour (perform TLS and authentication).
This also applies for existing configurations files that dont have the SMTP_SKIP_(TLS|LOGIN) variables.



