### PR TITLE
Update update_vendors.sh

### DIFF
--- a/back/update_vendors.sh
+++ b/back/update_vendors.sh
@@ -24,17 +24,17 @@ sudo mkdir -p 2_backup
 sudo cp *.txt 2_backup
 sudo cp *.csv 2_backup
 
-sudo curl $1 -# -O http://standards-oui.ieee.org/iab/iab.csv
-sudo curl $1 -# -O http://standards-oui.ieee.org/iab/iab.txt
+sudo curl $1 -# -LO http://standards-oui.ieee.org/iab/iab.csv
+sudo curl $1 -# -LO http://standards-oui.ieee.org/iab/iab.txt
 
-sudo curl $1 -# -O http://standards-oui.ieee.org/oui28/mam.csv
-sudo curl $1 -# -O http://standards-oui.ieee.org/oui28/mam.txt
+sudo curl $1 -# -LO http://standards-oui.ieee.org/oui28/mam.csv
+sudo curl $1 -# -LO http://standards-oui.ieee.org/oui28/mam.txt
 
-sudo curl $1 -# -O http://standards-oui.ieee.org/oui36/oui36.csv
-sudo curl $1 -# -O http://standards-oui.ieee.org/oui36/oui36.txt
+sudo curl $1 -# -LO http://standards-oui.ieee.org/oui36/oui36.csv
+sudo curl $1 -# -LO http://standards-oui.ieee.org/oui36/oui36.txt
 
-sudo curl $1 -# -O http://standards-oui.ieee.org/oui/oui.csv
-sudo curl $1 -# -O http://standards-oui.ieee.org/oui/oui.txt
+sudo curl $1 -# -LO http://standards-oui.ieee.org/oui/oui.csv
+sudo curl $1 -# -LO http://standards-oui.ieee.org/oui/oui.txt
 
 
 # ----------------------------------------------------------------------


### PR DESCRIPTION
-LO will follow redirects

-L in case the page has moved (3xx response) curl will redirect the request to the new address -o output to a file instead of stdout (usually the screen). In your case the o flag is redundant since the output is piped to bash (for execution) - not to a file.